### PR TITLE
The docker network must exist before we deploy infrastructure

### DIFF
--- a/src/ansible/kube_eng/playbooks/create_host_infra.yml
+++ b/src/ansible/kube_eng/playbooks/create_host_infra.yml
@@ -61,6 +61,10 @@
       directory: "{{ dist_dir }}/cloud-provider-mdns"
       user: "{{ user_id }}"
 
+  - name: Create a docker network to host infrastructure
+    community.docker.docker_network:
+      name: kind
+
   - name: Create a local PostgreSQL database container
     when: host.postgresql.enabled == true
     block:


### PR DESCRIPTION
Added an action to assert the 'kind' network exists to the make host-infra playbook, before we deploy postgres or minio to it.